### PR TITLE
Support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,11 @@
     "license": "Apache-2.0",
     "keywords": ["oauth", "rfc7636"],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ~8.0.0 || ~8.1.0",
         "ircmaxell/random-lib": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
@@ -22,5 +22,8 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "scripts": {
+        "test": "phpunit --colors=always"
     }
 }

--- a/tests/VerifierFactoryTest.php
+++ b/tests/VerifierFactoryTest.php
@@ -33,7 +33,7 @@ class VerifierFactoryTest extends \Bag2\OAuth\PKCE\TestCase
         $byte_length = 128;
         $actual = $this->subject->generate($byte_length, $method_name);
 
-        $this->assertInternalType('string', $actual[0]);
+        $this->assertIsString($actual[0]);
         $this->assertSame($byte_length, \strlen($actual[0]));
         $this->assertInstanceOf(Challenge::class, $actual[1]);
     }


### PR DESCRIPTION
This change allows `oauth-pkce` to support PHP up to version 8.1. 

As part of that change, the maximum version of PHPUnit has also been updated to the most recent release, and the tests have been updated to account for deprecations.