### PR TITLE
Add support for PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "Apache-2.0",
     "keywords": ["oauth", "rfc7636"],
     "require": {
-        "php": "^7.1 || ~8.0.0 || ~8.1.0",
+        "php": "^7.1 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "ircmaxell/random-lib": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
There doesn't seem to be anything in the code preventing it, and as [PHP 8.3 is right around the corner](https://stitcher.io/blog/new-in-php-83), to me at least, it makes sense to add support for PHP 8.2.